### PR TITLE
chore DTO & fix 개발환경중 조회수 2배 복사버그 수정

### DIFF
--- a/src/app/review-detail/[id]/page.tsx
+++ b/src/app/review-detail/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import useReviews from '@/lib/api/review/review';
 import NavigationBar from '@/components/common/NavigationBar/NavigationBar';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useParams } from 'next/navigation'; // useParams 사용
 
 export default function Page() {
@@ -18,8 +18,11 @@ export default function Page() {
   const [review, setReview] = useState<any>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const hasFetched = useRef<boolean>(false); // 중복방지
 
   useEffect(() => {
+    if (hasFetched.current) return; // ✅ 이미 요청했으면 실행하지 않음
+    hasFetched.current = true; // ✅ 요청 완료 상태로 변경
     const fetchData = async () => {
       try {
         const reviewData = await fetchReviewById(reviewId);

--- a/src/components/common/LargeReview/LargeReviewItem.tsx
+++ b/src/components/common/LargeReview/LargeReviewItem.tsx
@@ -40,6 +40,9 @@ const LargeReviewItem: React.FC<LargeReviewItemProps> = ({ review }) => {
               조회수: {review.viewCount}
             </p>
             <p className="mx-2 text-xs text-gray-500">
+              추천수: {review.recommendCount}
+            </p>
+            <p className="mx-2 text-xs text-gray-500">
               댓글: {review.commentCount}
             </p>
           </div>
@@ -73,7 +76,9 @@ const LargeReviewItem: React.FC<LargeReviewItemProps> = ({ review }) => {
 
         <div className="flex flex-row space-x-2 mt-2">
           {/* 이미지가 있으면 이미지들을 표시 */}
-          {review.imageUrls && review.imageUrls.length > 0 ? (
+          {(review.spoilerStatus === 'FALSE' || showSpoiler) &&
+          review.imageUrls &&
+          review.imageUrls.length > 0 ? (
             review.imageUrls.map((url, index) => (
               <img
                 key={index}

--- a/src/components/common/SmallReviewList/SmallReviewItem.tsx
+++ b/src/components/common/SmallReviewList/SmallReviewItem.tsx
@@ -24,6 +24,7 @@ const SmallReviewItem: React.FC<{ review: ReviewItemResponseDto }> = ({
           <p>웹툰명: {review.webtoonName}</p>
           <div className="flex space-x-2">
             <p>조회수: {review.viewCount}</p>
+            <p>추천수: {review.recommendCount}</p>
             <p>댓글: {review.commentCount}</p>
           </div>
         </div>

--- a/src/lib/types/review/ReviewDetailResponseDto.ts
+++ b/src/lib/types/review/ReviewDetailResponseDto.ts
@@ -20,4 +20,10 @@ export interface ReviewDetailResponseDto {
     hasPrevious: boolean;
     last: boolean;
   };
+  createdAt: string;
+  updatedAt: string | null;
+  recommendCount: {
+    hates: number;
+    likes: number;
+  };
 }

--- a/src/lib/types/review/ReviewItemResponseDto.ts
+++ b/src/lib/types/review/ReviewItemResponseDto.ts
@@ -12,4 +12,5 @@ export interface ReviewItemResponseDto {
   thumbnailUrl: string;
   imageUrls: string[];
   commentCount: number;
+  recommendCount: number;
 }


### PR DESCRIPTION
백엔드 DTO 변경사항이 있어 프론트에도 반영했습니다.

review-detail 개발환경에서 실행했을 때 페이지 들어갈 때마다 조회수가 2개 오르길래 찾아보니

fetch가 두번일어날 수 있다고 해서 그에 따른 수정을 했습니다.

reviewItem에 원래 figma에는 댓글 추천밖에 없었던 걸로 아는데 기존에 조회수 넣어둔것도 쓸모가 있다 생각해서

조회수는 추천 완료 전에만 넣어두려고 했는데 그냥 3개 다넣었습니다.