### PR TITLE
feat: 리뷰 스포일러 신고버튼

### DIFF
--- a/src/components/buisness/review/ReviewContentBox.tsx
+++ b/src/components/buisness/review/ReviewContentBox.tsx
@@ -30,14 +30,15 @@ const ReviewContentBox: React.FC<ReviewContentBoxProps> = ({ review }) => {
 
       {/* 이미지 리스트 */}
       {review.imageUrls.length > 0 && (
-        <div className="mt-4 grid grid-cols-2 md:grid-cols-3 gap-2">
+        <div className="mt-4 flex flex-wrap justify-center gap-2">
           {review.imageUrls.map((url, index) => (
-            <img
-              key={index}
-              src={url}
-              alt={`리뷰 이미지 ${index + 1}`}
-              className="w-full h-auto rounded-md"
-            />
+            <div key={index} className="flex justify-center items-center">
+              <img
+                src={url}
+                alt={`리뷰 이미지 ${index + 1}`}
+                className="w-auto h-auto max-w-[300px] max-h-[225px] object-contain rounded-md"
+              />
+            </div>
           ))}
         </div>
       )}

--- a/src/components/buisness/review/ReviewContentBox.tsx
+++ b/src/components/buisness/review/ReviewContentBox.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ReviewDetailResponseDto } from '@/lib/types/review/ReviewDetailResponseDto';
+import SpoilerButton from '@/components/common/SpoilerButton/SpoilerButton';
 
 interface ReviewContentBoxProps {
   review: ReviewDetailResponseDto;
@@ -8,12 +9,17 @@ interface ReviewContentBoxProps {
 const ReviewContentBox: React.FC<ReviewContentBoxProps> = ({ review }) => {
   return (
     <div className="bg-white p-6 rounded-lg shadow-md">
-      {/* 제목 */}
-      <h2 className="text-2xl font-bold mb-2">{review.title}</h2>
+      {/* 제목 & 신고 버튼 */}
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="text-2xl font-bold flex-grow">{review.title}</h2>
+        {review.spoilerStatus === 'FALSE' && (
+          <SpoilerButton reviewId={review.reviewId} />
+        )}
+      </div>
 
       {/* 스포일러 경고 */}
       {review.spoilerStatus === 'TRUE' && (
-        <p className="text-red-500 font-semibold">⚠️ 스포일러 포함</p>
+        <p className="text-red-500 font-semibold mb-4">⚠️ 스포일러 포함</p>
       )}
 
       {/* 프로필 정보 */}
@@ -30,7 +36,7 @@ const ReviewContentBox: React.FC<ReviewContentBoxProps> = ({ review }) => {
 
       {/* 이미지 리스트 */}
       {review.imageUrls.length > 0 && (
-        <div className="mt-4 flex flex-wrap justify-center gap-2">
+        <div className="mt-4 flex flex-wrap justify-start gap-2">
           {review.imageUrls.map((url, index) => (
             <div key={index} className="flex justify-center items-center">
               <img

--- a/src/components/common/LargeReviewList/LargeReviewItem.tsx
+++ b/src/components/common/LargeReviewList/LargeReviewItem.tsx
@@ -75,10 +75,8 @@ const LargeReviewItem: React.FC<LargeReviewItemProps> = ({ review }) => {
         )}
 
         <div className="flex flex-row space-x-2 mt-2">
-          {/* 이미지가 있으면 이미지들을 표시 */}
           {(review.spoilerStatus === 'FALSE' || showSpoiler) &&
-          review.imageUrls &&
-          review.imageUrls.length > 0 ? (
+            review.imageUrls?.length > 0 &&
             review.imageUrls.map((url, index) => (
               <img
                 key={index}
@@ -86,10 +84,7 @@ const LargeReviewItem: React.FC<LargeReviewItemProps> = ({ review }) => {
                 alt={`리뷰 이미지 ${index + 1}`}
                 className="border border-gray-300 w-[200px] h-[150px] object-cover"
               />
-            ))
-          ) : (
-            <span className="text-xs text-gray-500">이미지가 없습니다.</span>
-          )}
+            ))}
         </div>
         <div></div>
       </div>

--- a/src/components/common/SpoilerButton/SpoilerButton.tsx
+++ b/src/components/common/SpoilerButton/SpoilerButton.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import useReviews from '@/lib/api/review/review';
+
+const SpoilerButton = ({ reviewId }: { reviewId: number }) => {
+  const { spoilerReview } = useReviews();
+  const [loading, setLoading] = useState(false);
+
+  const handleSpoiler = async () => {
+    setLoading(true);
+    await spoilerReview(reviewId);
+    setLoading(false);
+  };
+
+  return (
+    <button
+      onClick={handleSpoiler}
+      disabled={loading}
+      className={`flex items-center space-x-2 bg-red-500 text-white px-2 py-1 rounded-md 
+        transition duration-200 hover:bg-red-600 disabled:bg-gray-400 disabled:cursor-not-allowed`}
+    >
+      <span className="text-lg">🚨</span>
+      <span>{loading ? '신고 중...' : '스포일러 신고'}</span>
+    </button>
+  );
+};
+
+export default SpoilerButton;

--- a/src/components/common/SpoilerButton/SpoilerButton.tsx
+++ b/src/components/common/SpoilerButton/SpoilerButton.tsx
@@ -9,14 +9,16 @@ const SpoilerButton = ({ reviewId }: { reviewId: number }) => {
     setLoading(true);
     await spoilerReview(reviewId);
     setLoading(false);
+    window.alert('🚨 신고가 완료되었습니다!');
+    window.location.reload();
   };
 
   return (
     <button
       onClick={handleSpoiler}
       disabled={loading}
-      className={`flex items-center space-x-2 bg-red-500 text-white px-2 py-1 rounded-md 
-        transition duration-200 hover:bg-red-600 disabled:bg-gray-400 disabled:cursor-not-allowed`}
+      className={`flex items-center space-x-2 bg-red-500 text-white px-3 py-1 rounded-md
+                     transition duration-200 hover:bg-red-600 text-sm disabled:bg-gray-400 disabled:cursor-not-allowed`}
     >
       <span className="text-lg">🚨</span>
       <span>{loading ? '신고 중...' : '스포일러 신고'}</span>

--- a/src/lib/api/review/review.ts
+++ b/src/lib/api/review/review.ts
@@ -224,7 +224,7 @@ const useReviews = (page: number = 0, size: number = 10) => {
   // 게시글 스포일러 요청
   const spoilerReview = async (reviewId: number) => {
     try {
-      await axios.delete(`http://localhost:8080/reviews/spoiler/${reviewId}`);
+      await axios.patch(`http://localhost:8080/reviews/spoiler/${reviewId}`);
     } catch (err: any) {
       setError('리뷰를 스포일러 등록하는데 실패했습니다.');
     }

--- a/src/lib/api/review/review.ts
+++ b/src/lib/api/review/review.ts
@@ -221,6 +221,15 @@ const useReviews = (page: number = 0, size: number = 10) => {
     }
   };
 
+  // 게시글 스포일러 요청
+  const spoilerReview = async (reviewId: number) => {
+    try {
+      await axios.delete(`http://localhost:8080/reviews/spoiler/${reviewId}`);
+    } catch (err: any) {
+      setError('리뷰를 스포일러 등록하는데 실패했습니다.');
+    }
+  };
+
   return {
     reviews,
     loading,
@@ -235,6 +244,7 @@ const useReviews = (page: number = 0, size: number = 10) => {
     updateReview,
     deleteReview,
     getWebtoonReviews,
+    spoilerReview,
   };
 };
 


### PR DESCRIPTION
스포일러가 아닌 리뷰에만 나옵니다. (이미 스포일러인걸 신고할 필요가 없으니까)

스포일러 버튼 누르고 나서 버튼 누른 사람한테 보여줄 화면은 아직입니다.

일단 예정은 화면에 [신고가 완료되었습니다] 띄우고 새로고침 시키려고 합니다.

스포일러 버튼 새로고침 처리 >>> 완료했습니다