### PR TITLE
fix: vote.ts 401error 처리

### DIFF
--- a/src/lib/api/voting/vote.ts
+++ b/src/lib/api/voting/vote.ts
@@ -84,8 +84,14 @@ const useVote = () => {
         );
       }
       return response.data;
-    } catch (err) {
-      setError('Failed to get vote status');
+    } catch (err: any) {
+      if (err.response?.status === 401) {
+        // 로그인 안 한 경우 조용히 무시
+        console.warn('로그인하지 않은 사용자 - 투표 상태 조회 건너뜀');
+        return null;
+      }
+
+      setError('Failed to get vote status'); // 다른 오류일 경우만 에러 표시
       console.error('❌ 투표 상태 조회 중 오류 발생:', err);
       return null;
     }


### PR DESCRIPTION
해결방법이 2가지 있었는데 더 효율이 좋다고 생각하는 방향으로 해결했습니다.

방법 1 : 로그인상태를 이용해서 요청을 받아오게 하는 방법
로그인이 되어있지 않은 상태에서 vote.ts의 요청이 실행되는게 문제이기 때문에 로그인 상태를 확인해서 요청
-> 로그인 상태를 파라미터로 전달해주거나, 로그인 상태 확인 통신을 하나 추가하던가 작업을 하고 또 로그인상태를 확인해 특정 훅이 작동되지 않게 해야 함. >> 번거로움

방법 2 : 로그인 여부에 상관업이 요청이 가는데 (기존과 같음) 대신 401 에러로 정리해두었기 때문에
401에러를 error가 아닌 warn 처리를 함.

방법 2로 선택했습니다.